### PR TITLE
update readme to reflect new defaultOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ const browserify = require('@cypress/browserify-preprocessor')
 
 module.exports = (on) => {
   const options = browserify.defaultOptions
-  options.transform[1][1].options.babelrc = true
-
+  options.browserifyOptions.transform[1][1].babelrc = true
+  
   on('file:preprocessor', browserify(options))
 }
 ```


### PR DESCRIPTION
At the moment the readme does not reflect the defaultOptions located here https://github.com/cypress-io/cypress-browserify-preprocessor/blob/master/index.js#L28