### PR TITLE
Add simple e2e test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 npm-debug.log
+_test-output

--- a/__snapshots__/e2e_spec.js
+++ b/__snapshots__/e2e_spec.js
@@ -1,0 +1,16 @@
+exports['browserify preprocessor - e2e correctly preprocesses the file 1'] = `
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+'use strict';
+
+it('is a test', function () {
+  var a = 1,
+      b = 2;
+
+  expect(a).to.equal(1);
+  expect(b).to.equal(2);
+  expect(Math.min.apply(Math, [3, 4])).to.equal(3);
+});
+
+},{}]},{},[1]);
+
+`

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
     "size": "t=\"$(npm pack .)\"; wc -c \"${t}\"; tar tvf \"${t}\"; rm \"${t}\";",
     "precommit": "npm run lint",
     "pretest": "npm run lint",
-    "test": "mocha",
+    "test": "npm run test-unit && npm run test-e2e",
+    "test-e2e": "mocha test/e2e/*.js",
+    "test-unit": "mocha test/unit/*.js",
     "test-debug": "node --inspect --debug-brk ./node_modules/.bin/_mocha",
-    "test-watch": "chokidar '*.js' 'test/*.js' -c 'npm test'",
+    "test-watch": "chokidar '*.js' 'test/unit/*.js' -c 'npm test'",
     "semantic-release": "semantic-release pre && npm publish --access public && semantic-release post"
   },
   "devDependencies": {
@@ -56,7 +58,8 @@
     "semantic-release": "8.2.0",
     "simple-commit-message": "3.3.1",
     "sinon": "3.2.1",
-    "sinon-chai": "2.13.0"
+    "sinon-chai": "2.13.0",
+    "snap-shot-it": "5.0.1"
   },
   "dependencies": {
     "babel-plugin-add-module-exports": "0.2.1",

--- a/test/e2e/e2e_spec.js
+++ b/test/e2e/e2e_spec.js
@@ -1,0 +1,21 @@
+const path = require('path')
+const snapshot = require('snap-shot-it')
+
+const fs = require('../../fs')
+const preprocessor = require('../../index')
+
+describe('browserify preprocessor - e2e', function () {
+  const on = () => {}
+
+  beforeEach(function () {
+    fs.removeSync(path.join(__dirname, '_test-output'))
+  })
+
+  it('correctly preprocesses the file', function () {
+    const filePath = path.join(__dirname, '..', 'fixtures', 'example_spec.js')
+    const outputPath = path.join(__dirname, '..', '_test-output', 'output.js')
+    return preprocessor()({ filePath, outputPath, on }).then(() => {
+      snapshot(fs.readFileSync(outputPath).toString())
+    })
+  })
+})

--- a/test/fixtures/example_spec.js
+++ b/test/fixtures/example_spec.js
@@ -1,0 +1,6 @@
+it('is a test', () => {
+  const [a, b] = [1, 2]
+  expect(a).to.equal(1)
+  expect(b).to.equal(2)
+  expect(Math.min(...[3, 4])).to.equal(3)
+})

--- a/test/unit/index_spec.js
+++ b/test/unit/index_spec.js
@@ -20,8 +20,8 @@ const streamApi = {
 }
 streamApi.on = sandbox.stub().returns(streamApi)
 
-const fs = require('../fs')
-const preprocessor = require('../index')
+const fs = require('../../fs')
+const preprocessor = require('../../index')
 
 describe('browserify preprocessor', function () {
   beforeEach(function () {


### PR DESCRIPTION
This will help catch issue when upgrading dependencies. 

The snapshot is of a transpiled file. It may change and fail the test when upgrading a dependency, but that's expected. We need to manually verify the snapshot change looks normal, then update it.