### PR TITLE
Add more typescript option validation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "eslint.enable": true,
-  "editor.formatOnSave": true,
   // enable for eslint-plugin json-format
-  "eslint.validate": ["json"],
+  "eslint.validate": [
+    "json"
+  ],
 }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const typescriptExtensionRegex = /\.tsx?$/
 const errorTypes = {
   TYPESCRIPT_AND_TSIFY: 'TYPESCRIPT_AND_TSIFY',
   TYPESCRIPT_NONEXISTENT: 'TYPESCRIPT_NONEXISTENT',
+  TYPESCRIPT_NOT_CONFIGURED: 'TYPESCRIPT_NOT_CONFIGURED',
   TYPESCRIPT_NOT_STRING: 'TYPESCRIPT_NOT_STRING',
 }
 
@@ -192,6 +193,15 @@ const preprocessor = (options = {}) => {
 
     const browserifyOptions = await getBrowserifyOptions(filePath, options.browserifyOptions, options.typescript)
     const watchifyOptions = Object.assign({}, defaultOptions.watchifyOptions, options.watchifyOptions)
+
+    if (!options.typescript && typescriptExtensionRegex.test(filePath)) {
+      throwError({
+        type: errorTypes.TYPESCRIPT_NOT_CONFIGURED,
+        message: `You are attempting to preprocess a TypeScript file, but do not have TypeScript configured. Pass the 'typescript' option to enable TypeScript support.
+
+The file: ${filePath}`,
+      })
+    }
 
     const bundler = browserify(browserifyOptions)
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 const Promise = require('bluebird')
-const fs = require('./lib/fs')
+const fs = require('fs-extra')
 
 const cloneDeep = require('lodash.clonedeep')
 const browserify = require('browserify')
@@ -227,7 +227,7 @@ const preprocessor = (options = {}) => {
     })
 
     const bundlePromise = fs
-    .ensureDirAsync(path.dirname(outputPath))
+    .ensureDir(path.dirname(outputPath))
     .then(bundle)
 
     // cache the bundle promise, so it can be returned if this function

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1,3 +1,0 @@
-const Promise = require('bluebird')
-
-module.exports = Promise.promisifyAll(require('fs-extra'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1344,6 +1344,17 @@
             "indent-string": "^3.0.0"
           }
         },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
         "glob": {
           "version": "7.1.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -1931,6 +1942,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.1",
@@ -5097,13 +5113,35 @@
       }
     },
     "fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+        }
       }
     },
     "fs.realpath": {
@@ -6495,6 +6533,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -13693,7 +13732,8 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "lib/*.js"
   ],
   "engines": {
-    "node": ">=6.5"
+    "node": ">=8"
   },
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "coffeeify": "3.0.1",
     "coffeescript": "1.12.7",
     "debug": "4.1.1",
-    "fs-extra": "7.0.1",
+    "fs-extra": "9.0.0",
     "lodash.clonedeep": "4.5.0",
     "through2": "^2.0.0",
     "watchify": "3.11.1"

--- a/test/e2e/e2e_spec.js
+++ b/test/e2e/e2e_spec.js
@@ -1,12 +1,12 @@
 const _ = require('lodash')
 const chai = require('chai')
+const fs = require('fs-extra')
 const path = require('path')
 const snapshot = require('snap-shot-it')
 const Bluebird = require('bluebird')
 
 process.env.__TESTING__ = true
 
-const fs = require('../../lib/fs')
 const preprocessor = require('../../index')
 
 /* eslint-disable-next-line no-unused-vars */
@@ -49,7 +49,7 @@ const verifySourceContents = ({ sources, sourcesContent }) => {
   const zippedArrays = _.zip(sources, sourcesContent)
 
   return Bluebird.map(zippedArrays, ([sourcePath, sourceContent]) => {
-    return fs.readFileAsync(sourcePath, 'utf8')
+    return fs.readFile(sourcePath, 'utf8')
     .then((str) => {
       expect(str).to.eq(sourceContent)
     })

--- a/test/unit/index_spec.js
+++ b/test/unit/index_spec.js
@@ -429,13 +429,19 @@ describe('browserify preprocessor', function () {
           throw new Error('Should error, should not resolve')
         }
 
+        const verifyErrorIncludesPrefix = (err) => {
+          expect(err.message).to.include('Error running @cypress/browserify-preprocessor:')
+        }
+
         it('throws error when typescript path is not a string', function () {
           this.options.typescript = true
 
           return this.run()
           .then(shouldntResolve)
           .catch((err) => {
-            expect(err.message).to.equal(`The 'typescript' option must be a string. You passed: true`)
+            verifyErrorIncludesPrefix(err)
+            expect(err.type).to.equal(preprocessor.errorTypes.TYPESCRIPT_NOT_STRING)
+            expect(err.message).to.include(`The 'typescript' option must be a string. You passed: true`)
           })
         })
 
@@ -445,7 +451,9 @@ describe('browserify preprocessor', function () {
           return this.run()
           .then(shouldntResolve)
           .catch((err) => {
-            expect(err.message).to.equal(`The 'typescript' option must be a valid path to your TypeScript installation. We could not find anything at the following path: /nothing/here`)
+            verifyErrorIncludesPrefix(err)
+            expect(err.type).to.equal(preprocessor.errorTypes.TYPESCRIPT_NONEXISTENT)
+            expect(err.message).to.include(`The 'typescript' option must be a valid path to your TypeScript installation. We could not find anything at the following path: /nothing/here`)
           })
         })
 
@@ -457,7 +465,9 @@ describe('browserify preprocessor', function () {
           return this.run()
           .then(shouldntResolve)
           .catch((err) => {
-            expect(err.message).to.include('This may cause conflicts')
+            verifyErrorIncludesPrefix(err)
+            expect(err.type).to.equal(preprocessor.errorTypes.TYPESCRIPT_AND_TSIFY)
+            expect(err.message).to.include(`It looks like you passed the 'typescript' option and also specified a browserify plugin for TypeScript. This may cause conflicts`)
           })
         })
 
@@ -471,7 +481,11 @@ describe('browserify preprocessor', function () {
           return this.run()
           .then(shouldntResolve)
           .catch((err) => {
-            expect(err.message).to.include('This may cause conflicts')
+            verifyErrorIncludesPrefix(err)
+            expect(err.type).to.equal(preprocessor.errorTypes.TYPESCRIPT_AND_TSIFY)
+            expect(err.message).to.include(`It looks like you passed the 'typescript' option and also specified a browserify transform for TypeScript. This may cause conflicts`)
+          })
+        })
           })
         })
       })

--- a/test/unit/index_spec.js
+++ b/test/unit/index_spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const chai = require('chai')
+const fs = require('fs-extra')
 const mockery = require('mockery')
 const sinon = require('sinon')
 const watchify = require('watchify')
@@ -28,7 +29,6 @@ streamApi.on = sandbox.stub().returns(streamApi)
 
 process.env.__TESTING__ = true
 
-const fs = require('../../lib/fs')
 const preprocessor = require('../../index')
 
 describe('browserify preprocessor', function () {
@@ -54,7 +54,7 @@ describe('browserify preprocessor', function () {
     }
 
     sandbox.stub(fs, 'createWriteStream').returns(this.createWriteStreamApi)
-    sandbox.stub(fs, 'ensureDirAsync').resolves()
+    sandbox.stub(fs, 'ensureDir').resolves()
 
     this.options = {}
     this.file = {
@@ -215,7 +215,7 @@ describe('browserify preprocessor', function () {
 
       it('ensures directory for output is created', function () {
         return this.run().then(() => {
-          expect(fs.ensureDirAsync).to.be.calledWith('output')
+          expect(fs.ensureDir).to.be.calledWith('output')
         })
       })
 

--- a/test/unit/index_spec.js
+++ b/test/unit/index_spec.js
@@ -204,7 +204,7 @@ describe('browserify preprocessor', function () {
       })
 
       it('uses transforms if provided', function () {
-        const transform = [() => {}, {}]
+        const transform = [() => { }, {}]
 
         this.options.browserifyOptions = { transform }
 
@@ -334,7 +334,7 @@ describe('browserify preprocessor', function () {
         }
 
         this.run().then(() => {
-          streamApi.on.withArgs('error').yieldsAsync(new Error('bundle error')).returns({ pipe () {} })
+          streamApi.on.withArgs('error').yieldsAsync(new Error('bundle error')).returns({ pipe () { } })
           this.bundlerApi.on.withArgs('update').yield()
         })
       })
@@ -345,7 +345,7 @@ describe('browserify preprocessor', function () {
 
         return run(this.file)
         .then(() => {
-          streamApi.on.withArgs('error').yieldsAsync(new Error('bundle error')).returns({ pipe () {} })
+          streamApi.on.withArgs('error').yieldsAsync(new Error('bundle error')).returns({ pipe () { } })
           this.bundlerApi.on.withArgs('update').yield()
 
           return run(this.file)

--- a/test/unit/index_spec.js
+++ b/test/unit/index_spec.js
@@ -486,6 +486,32 @@ describe('browserify preprocessor', function () {
             expect(err.message).to.include(`It looks like you passed the 'typescript' option and also specified a browserify transform for TypeScript. This may cause conflicts`)
           })
         })
+
+        it('throws error when processing .ts file and typescript option is not set', function () {
+          this.options.typescript = undefined
+          this.file.filePath = 'path/to/file.ts'
+
+          return this.run()
+          .then(shouldntResolve)
+          .catch((err) => {
+            verifyErrorIncludesPrefix(err)
+            expect(err.type).to.equal(preprocessor.errorTypes.TYPESCRIPT_NOT_CONFIGURED)
+            expect(err.message).to.include(`You are attempting to preprocess a TypeScript file, but do not have TypeScript configured. Pass the 'typescript' option to enable TypeScript support`)
+            expect(err.message).to.include('path/to/file.ts')
+          })
+        })
+
+        it('throws error when processing .tsx file and typescript option is not set', function () {
+          this.options.typescript = undefined
+          this.file.filePath = 'path/to/file.tsx'
+
+          return this.run()
+          .then(shouldntResolve)
+          .catch((err) => {
+            verifyErrorIncludesPrefix(err)
+            expect(err.type).to.equal(preprocessor.errorTypes.TYPESCRIPT_NOT_CONFIGURED)
+            expect(err.message).to.include(`You are attempting to preprocess a TypeScript file, but do not have TypeScript configured. Pass the 'typescript' option to enable TypeScript support`)
+            expect(err.message).to.include('path/to/file.tsx')
           })
         })
       })

--- a/test/unit/index_spec.js
+++ b/test/unit/index_spec.js
@@ -424,23 +424,55 @@ describe('browserify preprocessor', function () {
         })
       })
 
-      describe('when typescript path and tsify are given together', function () {
-        it('throws error when it is a plugin', function () {
+      describe('validation', function () {
+        const shouldntResolve = () => {
+          throw new Error('Should error, should not resolve')
+        }
+
+        it('throws error when typescript path is not a string', function () {
+          this.options.typescript = true
+
+          return this.run()
+          .then(shouldntResolve)
+          .catch((err) => {
+            expect(err.message).to.equal(`The 'typescript' option must be a string. You passed: true`)
+          })
+        })
+
+        it('throws error when nothing exists at typescript path', function () {
+          this.options.typescript = '/nothing/here'
+
+          return this.run()
+          .then(shouldntResolve)
+          .catch((err) => {
+            expect(err.message).to.equal(`The 'typescript' option must be a valid path to your TypeScript installation. We could not find anything at the following path: /nothing/here`)
+          })
+        })
+
+        it('throws error when typescript path and tsify plugin are specified', function () {
           this.options.browserifyOptions = {
             plugin: ['tsify'],
           }
 
-          expect(this.run).to.throw('This may cause conflicts')
+          return this.run()
+          .then(shouldntResolve)
+          .catch((err) => {
+            expect(err.message).to.include('This may cause conflicts')
+          })
         })
 
-        it('throws error when it is a transform', function () {
+        it('throws error when typescript path and tsify transform are specified', function () {
           this.options.browserifyOptions = {
             transform: [
               ['path/to/tsify', {}],
             ],
           }
 
-          expect(this.run).to.throw('This may cause conflicts')
+          return this.run()
+          .then(shouldntResolve)
+          .catch((err) => {
+            expect(err.message).to.include('This may cause conflicts')
+          })
         })
       })
     })


### PR DESCRIPTION
- Closes #46
- Closes #47

Adds more validation for the typescript option.

If you pass the a non-string for the typescript option, you'll get the following error:

```
Error running @cypress/browserify-preprocessor:

The 'typescript' option must be a string. You passed: {}
```

If you pass the a path for the typescript option but nothing exists at that path, you'll get the following error:

```
Error running @cypress/browserify-preprocessor:

The 'typescript' option must be a valid path to your TypeScript installation. We could not find anything at the following path: /does/not/exist/typescript.js
```

If you try to preprocess a `.ts` or `.tsx` file, but don't have the `typescript` option set, you'll get the following error:

```
Error running @cypress/browserify-preprocessor:

You are attempting to preprocess a TypeScript file, but do not have TypeScript configured. Pass the 'typescript' option to enable TypeScript support.

The file: /path/to/cypress/integration/foo_spec.ts`
```

For the last one, I'm planning to add special handling in Cypress itself. Since we try to set the `typescript` option for the user, it's opaque when we can't find it but still carry on and try to run TypeScript specs. The user didn't set up the preprocessor themselves, so they can't exactly fix the issue themselves. Instead, when Cypress is handling the preprocessor and encounters this error, it will have a more tailored error message.