### PR TITLE
fix: Handle function transforms when `typescript` is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const getBrowserifyOptions = async (entry, userBrowserifyOptions = {}, typescrip
     }
 
     const transform = browserifyOptions.transform
-    const hasTsifyTransform = transform.some(([name]) => name.includes('tsify'))
+    const hasTsifyTransform = transform.some((stage) => Array.isArray(stage) && stage[0].includes('tsify'))
     const hastsifyPlugin = browserifyOptions.plugin.includes('tsify')
 
     if (hasTsifyTransform || hastsifyPlugin) {
@@ -136,7 +136,7 @@ Please do one of the following:
 
     browserifyOptions.extensions.push('.ts', '.tsx')
     // remove babelify setting
-    browserifyOptions.transform = transform.filter(([name]) => !name.includes('babelify'))
+    browserifyOptions.transform = transform.filter((stage) => !Array.isArray(stage) || !stage[0].includes('babelify'))
     // add typescript compiler
     browserifyOptions.transform.push([
       path.join(__dirname, './lib/simple_tsify'), {

--- a/test/unit/index_spec.js
+++ b/test/unit/index_spec.js
@@ -380,6 +380,21 @@ describe('browserify preprocessor', function () {
         })
       })
 
+      // Regression test for cypress-io/cypress-browserify-preprocessor#56
+      it('handles transforms defined as functions', function () {
+        this.createWriteStreamApi.on.withArgs('finish').yields()
+
+        const transform = [() => { }, {}]
+
+        this.options.browserifyOptions = { transform }
+
+        return this.run().then(() => {
+          transform.forEach((stage, stageIndex) => {
+            expect(browserify.lastCall.args[0].transform[stageIndex]).to.eql(stage)
+          })
+        })
+      })
+
       it('removes babelify transform', function () {
         this.createWriteStreamApi.on.withArgs('finish').yields()
 


### PR DESCRIPTION
This implements the fixes proposed by #56 with a regression test to verify the behavior.