### PR TITLE
docs: updates docs to only support cypress < 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ npm install --save-dev @cypress/browserify-preprocessor
 
 ## Usage
 
+### Note: This Plugin only works for Cypress < 10
+
 In your project's [plugins file](https://on.cypress.io/plugins-guide):
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install --save-dev @cypress/browserify-preprocessor
 
 ## Usage
 
-### Note: This Plugin only works for Cypress < 10
+### Note: This Plugin only works for Cypress < 9
 
 In your project's [plugins file](https://on.cypress.io/plugins-guide):
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## Note: This plugin is deprecated and Cypress will not be moving forward with development of the plugin.
+
 # Cypress Browserify Preprocessor [![CircleCI](https://circleci.com/gh/cypress-io/cypress-browserify-preprocessor/tree/master.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress-browserify-preprocessor/tree/master)
 
 Cypress preprocessor for bundling JavaScript via browserify.
@@ -17,8 +19,6 @@ npm install --save-dev @cypress/browserify-preprocessor
 ```
 
 ## Usage
-
-### Note: This Plugin only works for Cypress < 9
 
 In your project's [plugins file](https://on.cypress.io/plugins-guide):
 


### PR DESCRIPTION
This PR mentions that it only support Cypress 9 and lower

Closes UDX-112